### PR TITLE
Add comment about 1p cli deploy syntax

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -2,6 +2,11 @@
 
 # In order to use this script, first configure middleman-s3_sync
 # in config.rb
+#
+# To run this script using 1Password cli credentials, use this command:
+# op run -- bin/deploy production
+#
+# More info: https://developer.1password.com/docs/cli/secrets-environment-variables#export-environment-variables
 
 set -e
 ENV=$1


### PR DESCRIPTION
This should have been added in PR #88 but I forgot. 😬 It's relevant for deploys when using 1Password CLI to manage secrets like AWS keys.

https://developer.1password.com/docs/cli/secrets-environment-variables/#export-environment-variables